### PR TITLE
Hotfix/send to email rebased

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,11 @@
 
                  [environ "1.1.0"]
                  [clojure-humanize "0.2.2"]
+
+                 ;; qrcode generation and scanning
                  [clj.qrgen "0.4.0"]
+                 [com.google.zxing/core "3.2.1"]
+                 
                  [clavatar "0.3.0"]
                  [circleci/clj-yaml "0.5.6"]
 

--- a/src/freecoin/handlers/qrcode.clj
+++ b/src/freecoin/handlers/qrcode.clj
@@ -3,11 +3,11 @@
 ;; part of Decentralized Citizen Engagement Technologies (D-CENT)
 ;; R&D funded by the European Commission (FP7/CAPS 610349)
 
-;; Copyright (C) 2015 Dyne.org foundation
-;; Copyright (C) 2015 Thoughtworks, Inc.
+;; Copyright (C) 2017 Dyne.org foundation
 
 ;; Sourcecode designed, written and maintained by
 ;; Denis Roio <jaromil@dyne.org>
+;; Aspasia Beneti <aspra@dyne.org>
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU Affero General Public License as published by
@@ -24,16 +24,16 @@
 
 (ns freecoin.handlers.qrcode
   (:require [liberator.core :as lc]
-            [freecoin.params :as param]
+            [freecoin.config :as config]
             [freecoin.auth :as auth]
             [freecoin-lib.db.wallet :as wallet]
             [freecoin.context-helpers :as ch]
             [clj.qrgen :as qr]
             [taoensso.timbre :as log]))
 
-
 (lc/defresource qr-participant-sendto [wallet-store]
   :allowed-methods [:get]
+
   :available-media-types ["image/png"]
 
   :authorized? #(auth/is-signed-in %)
@@ -44,7 +44,7 @@
   :handle-ok
   (fn [ctx]
     (if-let [email (get-in ctx [:request :params :email])]
-      (qr/as-input-stream
-       (qr/from (format "http://%s:%d/send/to/%s"
-                        (:address param/host)
-                        (:port param/host) email))))))
+      (let [base-url (-> (config/create-config) config/base-url)]
+        (qr/as-input-stream
+         (qr/from (str base-url "/send/to/" email)
+                  :charset "ISO-8859-1"))))))

--- a/src/freecoin/handlers/qrcode.clj
+++ b/src/freecoin/handlers/qrcode.clj
@@ -24,7 +24,7 @@
 
 (ns freecoin.handlers.qrcode
   (:require [liberator.core :as lc]
-            [freecoin.config :as config]
+            [freecoin-lib.config :as config]
             [freecoin.auth :as auth]
             [freecoin-lib.db.wallet :as wallet]
             [freecoin.context-helpers :as ch]

--- a/src/freecoin/params.clj
+++ b/src/freecoin/params.clj
@@ -30,11 +30,6 @@
 
 (def version "software release version" "0.2")
 
-;; TODO: perhaps already configured in ring?
-(def host
-  {:address "fork"
-   :port 8000})
-
 ;; defaults
 (def encryption
   {:version 1

--- a/src/freecoin/views/transaction_form.clj
+++ b/src/freecoin/views/transaction_form.clj
@@ -52,7 +52,7 @@
                    :method "POST"}
             [:input {:name "__anti-forgery-token"
                      :type "hidden"
-                     :value (get-in ctx [:session "__anti-forgery-token"])}]
+                     :value (get-in ctx [:request :session "__anti-forgery-token"])}]
             [:input {:name "recipient"
                      :type "hidden"
                      :value email}]

--- a/src/freecoin/views/transaction_form.clj
+++ b/src/freecoin/views/transaction_form.clj
@@ -48,7 +48,7 @@
     {:title   (str (t/locale [:transaction :make]) " -> " email)
      :heading (str (t/locale [:transaction :send]) " -> " email)
      :body [:form {:action (routes/absolute-path :post-transaction-form)
-                   :class "form-shell"
+                   :class "func--transaction-to-body"
                    :method "POST"}
             [:input {:name "__anti-forgery-token"
                      :type "hidden"
@@ -62,7 +62,7 @@
              [:div {:class "form-group"}
               [:label {:class "control-label"
                        :for   "field-amount"} "Amount"]
-              [:input {:class "form-control"
+              [:input {:class "form-control func--transaction-to-amount"
                        :id    "field-amount"
                        :name "amount"
                        :type "decimal"
@@ -70,17 +70,17 @@
              [:div {:class "form-group"}
               [:label {:class "control-label"
                        :for   "field-tags"} "Tags"]
-               [:input {:class "form-control"
-                        :id    "field-tags"
-                        :name "tags"
-                        :type "decimal"
-                        :value ""}]]
+              [:input {:class "form-control func--transaction-to-tags"
+                       :id    "field-tags"
+                       :name "tags"
+                       :type "decimal"
+                       :value ""}]]
              ]
 
             [:fieldset {:class "fieldset-submit"}
              [:div {:class "form-group"}
               [:span {:class "visible-xs-inline-block visible-sm-inline-block visible-md-inline-block visible-lg-inline-block"}
-               [:input {:class "form-control btn btn-primary"
+               [:input {:class "form-control btn btn-primary func--transaction-to-submit"
                         :id "field-submit"
                         :name "submit"
                         :type "submit"}]]]]

--- a/src/freecoin/views/transaction_form.clj
+++ b/src/freecoin/views/transaction_form.clj
@@ -44,8 +44,7 @@
 ;; build a more complex transaction form with hidden fields
 ;; not using formalize here, but hiccup directly
 (defn build-transaction-to [ctx]
-  (if-let [email (get-in ctx [:params :email])]
-
+  (if-let [email (get-in ctx [:request :params :email])]
     {:title   (str (t/locale [:transaction :make]) " -> " email)
      :heading (str (t/locale [:transaction :send]) " -> " email)
      :body [:form {:action (routes/absolute-path :post-transaction-form)

--- a/src/freecoin/views/transaction_form.clj
+++ b/src/freecoin/views/transaction_form.clj
@@ -52,7 +52,7 @@
                    :method "POST"}
             [:input {:name "__anti-forgery-token"
                      :type "hidden"
-                     :value (get-in ctx [:request :session "__anti-forgery-token"])}]
+                     :value (get-in ctx [:request :session :ring.middleware.anti-forgery/anti-forgery-token])}]
             [:input {:name "recipient"
                      :type "hidden"
                      :value email}]

--- a/test/freecoin/journey/kerodon_selectors.clj
+++ b/test/freecoin/journey/kerodon_selectors.clj
@@ -22,6 +22,11 @@
 (def transactions-page-body :.func--transactions-page--body)
 (def transactions-page--table-rows [:.func--transactions-page--table :tbody :tr])
 
+(def transaction-to-amount :.func--transaction-to-amount)
+(def transaction-to-tags :.func--transaction-to-tags)
+(def transaction-to-submit :.func--transaction-to-submit)
+(def transaction-to-body :.func--transaction-to-body)
+
 (def tags-page-body :.func--tags-page--body)
 (def tags-page--table-rows [:.func--tags-page--table :tbody :tr])
 (def tags-page--table-rows--amount [:.func--tags-page--table :tbody :*:last-child])

--- a/test/freecoin/journey/transactions.clj
+++ b/test/freecoin/journey/transactions.clj
@@ -248,6 +248,6 @@
              (kc/check-and-fill-in ks/transaction-to-tags "test")
              (kc/check-and-press ks/transaction-to-submit)
 
-             (kc/check-and-follow-redirect "redirects to transaction cinfirmation page")
+             (kc/check-and-follow-redirect "redirects to transaction confirmation page")
              (kh/remember memory :confirmation-uid kh/state-on-account-page->email)
              (kc/check-page-is :get-confirm-transaction-form ks/transaction-to-body :confirmation-uid (kh/recall memory :confirmation-uid))))))

--- a/test/freecoin/journey/transactions.clj
+++ b/test/freecoin/journey/transactions.clj
@@ -225,3 +225,29 @@
              (kc/check-and-follow-redirect "back to form")
              (kc/check-page-is :get-transaction-form [ks/transaction-form--submit])
              (kc/selector-includes-content [ks/transaction-form--error-message] "To: Not found")))))
+
+(facts "Make a transaction to a user using his/her qrcode link"
+       (fact "The right error is returned"
+             (let [memory (atom {})]
+         (-> (k/session test-app)
+
+             (sign-up "recipient")
+             (activate-account (jh/get-activation-id stores-m recipient-email) recipient-email)
+             (sign-in "recipient")
+             (kh/remember memory :recipient-email kh/state-on-account-page->email)
+             sign-out
+
+             (sign-up "sender")
+             (activate-account (jh/get-activation-id stores-m sender-email) sender-email)
+             (sign-in "sender")
+             (kh/remember memory :sender-email kh/state-on-account-page->email)
+
+             ;; required form fields
+             (k/visit (routes/absolute-path :get-transaction-to :email recipient-email))
+             (kc/check-and-fill-in ks/transaction-to-amount "1")
+             (kc/check-and-fill-in ks/transaction-to-tags "test")
+             (kc/check-and-press ks/transaction-to-submit)
+
+             (kc/check-and-follow-redirect "redirects to transaction cinfirmation page")
+             (kh/remember memory :confirmation-uid kh/state-on-account-page->email)
+             (kc/check-page-is :get-confirm-transaction-form ks/transaction-to-body :confirmation-uid (kh/recall memory :confirmation-uid))))))

--- a/test/freecoin/test/handlers/qrcode.clj
+++ b/test/freecoin/test/handlers/qrcode.clj
@@ -1,0 +1,70 @@
+;; Freecoin - digital social currency toolkit
+
+;; part of Decentralized Citizen Engagement Technologies (D-CENT)
+;; R&D funded by the European Commission (FP7/CAPS 610349)
+
+;; Copyright (C) 2017 Dyne.org foundation
+
+;; Sourcecode designed, written and maintained by
+;; Aspasia Beneti <aspra@dyne.org>
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU Affero General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU Affero General Public License for more details.
+
+;; You should have received a copy of the GNU Affero General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+(ns freecoin.test.handlers.qrcode
+  (:require [midje.sweet :refer :all]
+            [ring.mock.request :as rmr]
+            [freecoin.db
+             [mongo :as fm]
+             [wallet :as w]]
+            [freecoin.blockchain :as fb]
+            [freecoin.handlers.qrcode :as handler]
+            [net.cgrand.enlive-html :as html]
+            [freecoin.test.test-helper :as th]
+            [taoensso.timbre :as log])
+  (:import [com.google.zxing BinaryBitmap
+            MultiFormatReader]
+           [com.google.zxing.client.j2se BufferedImageLuminanceSource]
+           [com.google.zxing.common HybridBinarizer]))
+
+(def user-email "user@mail.com")
+
+(defn qrcode->text [byte-array-input-stream]
+  (->> byte-array-input-stream
+      (javax.imageio.ImageIO/read)
+      (BufferedImageLuminanceSource.)
+      (HybridBinarizer.)
+      (BinaryBitmap.)
+      (.decode (MultiFormatReader.))
+      (.getText)))
+
+(facts "Read qrcode and perform a send to"
+       (fact "Requests the qr code for an email address"
+             (let [wallet-store (fm/create-memory-store)
+                   blockchain (fb/create-in-memory-blockchain :bk)
+                   wallet (:wallet (w/new-empty-wallet! wallet-store blockchain
+                                                        "name" user-email))
+                   qrcode-handler (handler/qr-participant-sendto wallet-store)
+                   response (qrcode-handler
+                             (-> (rmr/request :get "/qrcode/")
+                                 (assoc :params {:email user-email})
+                                 (assoc-in [:session :signed-in-email] user-email)))]
+               (:status response) => 200
+               (-> (:body response) (type)) =>  java.io.ByteArrayInputStream
+
+               (fact "Retrieves the URL from the QRCODE input stream"
+                     (let [url (qrcode->text (:body response))]
+                       (.contains url user-email) => truthy
+                       (.contains url "send/to") => truthy))
+
+               (fact "Performs a send to transaction based on the qrcode"))))

--- a/test/freecoin/test/handlers/qrcode.clj
+++ b/test/freecoin/test/handlers/qrcode.clj
@@ -24,10 +24,10 @@
 (ns freecoin.test.handlers.qrcode
   (:require [midje.sweet :refer :all]
             [ring.mock.request :as rmr]
-            [freecoin.db
+            [freecoin-lib.db
              [mongo :as fm]
              [wallet :as w]]
-            [freecoin.blockchain :as fb]
+            [freecoin-lib.core :as fb]
             [freecoin.handlers
              [qrcode :as handler]
              [transaction-form :as transaction-handler]]

--- a/test/freecoin/test/handlers/sign_in.clj
+++ b/test/freecoin/test/handlers/sign_in.clj
@@ -36,11 +36,6 @@
             [freecoin.email-activation :as email-activation]
             [taoensso.timbre :as log]))
 
-(def client-id "CLIENT_ID")
-(def client-secret "CLIENT_SECRET")
-(def callback-uri "CALLBACK_URI")
-(def public-key "PUBLICK_KEY") ;; TODO: load this from jwk file
-
 (def absolute-path (partial routes/absolute-path))
 
 (def empty-wallet {})


### PR DESCRIPTION
Replaces 
https://github.com/PIENews/freecoin/pull/66
https://github.com/PIENews/freecoin/pull/67

Rebased on top of develop:

A few fixes regarding the qrcode scan and transact functionality

the base-url is now correct
the response is no more empty
no anti-forgery token error anymore
tests were added