### PR TITLE
Feature/renaming

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -69,8 +69,7 @@
                           :repl-options {:init-ns freecoin.core}
                           :env [[:base-url "http://localhost:8000"]
                                 [:email-config "email-conf.edn"]
-                                [:secure "false"]
-                                [:admin-email "sender@mail.com"]
+                                [:secure "false"] 
                                 [:ttl-password-recovery "1800"]]
                           :plugins [[lein-midje "3.1.3"]]}
 

--- a/project.clj
+++ b/project.clj
@@ -50,7 +50,7 @@
   :jvm-opts ["-Djava.security.egd=file:/dev/random" ;use a proper random source (install haveged)
              "-XX:-OmitStackTraceInFastThrow" ; prevent JVM exceptions without stack trace
              ]
-  :env [[:base-url "http://localhost:8000"]
+  :env [
 
         ;; translation is configured here, strings are hard-coded at compile time
         ;; the last one acts as fallback if translated strings are not found

--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,7 @@
                  [org.clojars.dyne/fxc "0.5.0"]
 
                  ; freecoin core lib
-                 [org.clojars.dyne/freecoin-lib "0.2.0"]
+                 [org.clojars.dyne/freecoin-lib "0.3.0"]
 
                  ; email
                  [com.draines/postal "2.0.2"]]

--- a/src/freecoin/core.clj
+++ b/src/freecoin/core.clj
@@ -176,7 +176,7 @@
     (if-let [db (:db app-state)]
       (let [config-m           (config/create-config)
             stores-m           (storage/create-mongo-stores db (config/ttl-password-recovery config-m))
-            blockchain         (blockchain/new-stub stores-m)
+            blockchain         (blockchain/new-mongo stores-m)
             email-conf         (clojure.edn/read-string (slurp (:email-config config-m))) 
             email-activator    (freecoin.email-activation/->ActivationEmail email-conf (:account-store stores-m))
             password-recoverer (freecoin.email-activation/->PasswordRecoveryEmail email-conf (:password-recovery-store stores-m))
@@ -215,7 +215,7 @@
                        email-conf         (clojure.edn/read-string (slurp (:email-config config-m)))
                        db                 (:db @app-state)
                        stores-m           (storage/create-mongo-stores db (config/ttl-password-recovery config-m))
-                       blockchain         (blockchain/new-stub stores-m)
+                       blockchain         (blockchain/new-mongo stores-m)
                        email-activator    (freecoin.email-activation/->ActivationEmail email-conf (:account-store stores-m))
                        password-recoverer (freecoin.email-activation/->PasswordRecoveryEmail email-conf (:password-recovery-store stores-m))]
                    (prn "Restarting server....")

--- a/src/freecoin/core.clj
+++ b/src/freecoin/core.clj
@@ -80,7 +80,7 @@
         password-recovery-store (storage/get-password-recovery-store stores-m)]
     {
      :version                       (debug/version config-m)
-     :echo                          (debug/echo (dissoc config-m :admin-email))
+     :echo                          (debug/echo config-m)
      :qrcode                        (qrcode/qr-participant-sendto wallet-store)
      :index                         sign-in/index-page
      :landing-page                  (sign-in/landing-page wallet-store)
@@ -108,7 +108,7 @@
 
      :get-transaction-form          (transaction-form/get-transaction-form wallet-store)
      :get-transaction-to            (transaction-form/get-transaction-to wallet-store)
-     :post-transaction-form         (transaction-form/post-transaction-form blockchain wallet-store confirmation-store)
+     :post-transaction-form         (transaction-form/post-transaction-form blockchain wallet-store confirmation-store account-store)
 
      :get-all-tags                  (tags/get-tags blockchain)
      :get-tag-details               (tag/get-tag-details blockchain)

--- a/src/freecoin/handlers/confirm_transaction_form.clj
+++ b/src/freecoin/handlers/confirm_transaction_form.clj
@@ -111,10 +111,8 @@
           sender-wallet (wallet/fetch wallet-store sender-email)
           recipient-wallet (wallet/fetch wallet-store recipient-email)]
       (blockchain/make-transaction blockchain
-                                   ;; TODO: Replace account-id with email
-                                   (:account-id sender-wallet) amount
-                                   (:account-id recipient-wallet) {:tags tags}
-                                   (:email sender-wallet))
+                                   (:email sender-wallet) amount
+                                   (:email recipient-wallet) {:tags tags})
       (confirmation/delete!
        confirmation-store
        (-> ctx ::confirmation :uid))

--- a/src/freecoin/handlers/participants.clj
+++ b/src/freecoin/handlers/participants.clj
@@ -43,7 +43,7 @@
 
 (defn render-wallet [wallet blockchain]
   (-> {:wallet wallet
-       :balance (blockchain/get-balance blockchain (:account-id wallet))}
+       :balance (blockchain/get-balance blockchain (:email wallet))}
       account-page/build
       fv/render-page))
 

--- a/src/freecoin/handlers/transaction_form.clj
+++ b/src/freecoin/handlers/transaction_form.clj
@@ -77,7 +77,7 @@
                             (ch/context->params ctx))
           amount (:amount data)
           sender-email (ch/context->signed-in-email ctx)
-          sender-balance (blockchain/get-balance blockchain (:account-id (wallet/fetch wallet-store sender-email)))
+          sender-balance (blockchain/get-balance blockchain sender-email)
           admin-email (or (-> (config/create-config) config/admin-email) "")]
       (if (= :ok status)
         (if-let [recipient-wallet

--- a/src/freecoin/handlers/transactions_list.clj
+++ b/src/freecoin/handlers/transactions_list.clj
@@ -67,7 +67,7 @@
   (fn [ctx]
     (let [tags (-> ctx :request :params :tags parse-tags)]
       (-> blockchain
-          (blockchain/list-transactions (-> {:account-id (-> ctx :wallet :account-id)}
+          (blockchain/list-transactions (-> {:account-id (-> ctx :wallet :email)}
                                             (maybe-merge :tags tags seq)))
           (transaction-list/build-html tags wallet-store (:wallet ctx))
           fv/render-page))))

--- a/src/freecoin/views/transaction_list.clj
+++ b/src/freecoin/views/transaction_list.clj
@@ -82,8 +82,8 @@
          [:th "Tags"]]]
        [:tbody
         (map (fn [t]
-               (let [from (wallet/fetch-by-account-id wallet-store (:from-id t))
-                     to (wallet/fetch-by-account-id wallet-store (:to-id t))
+               (let [from (wallet/fetch wallet-store (:from-id t))
+                     to (wallet/fetch wallet-store (:to-id t))
                      tag (fn [t] [:span.tag [:a {:href (routes/path :get-tag-details :name t)} t]])]
                  [:tr
                   [:td [:a {:href (routes/path :account :email (:email from))} (:name from)]]
@@ -94,8 +94,8 @@
              list)]]]}))
 
 (defn transaction->activity-stream [tx wallet-store]
-  (let [from (wallet/fetch-by-account-id wallet-store (:from-id tx))
-        to (wallet/fetch-by-account-id wallet-store (:to-id tx))]
+  (let [from (wallet/fetch wallet-store (:from-id tx))
+        to (wallet/fetch wallet-store (:to-id tx))]
     {"@context"   "https://www.w3.org/ns/activitystreams"
      "type"      "Transaction"
      "published" (str (:timestamp tx) "Z")

--- a/test/freecoin/journey/activitystreams.clj
+++ b/test/freecoin/journey/activitystreams.clj
@@ -46,7 +46,7 @@
 (ih/setup-db)
 
 (def stores-m (s/create-mongo-stores (ih/get-test-db)))
-(def blockchain (blockchain/new-stub stores-m))
+(def blockchain (blockchain/new-mongo stores-m))
 
 (def test-app (ih/build-app {:stores-m stores-m
                              :blockchain blockchain}))

--- a/test/freecoin/journey/activitystreams.clj
+++ b/test/freecoin/journey/activitystreams.clj
@@ -87,12 +87,9 @@
   state)
 
 (defn make-transaction [state blockchain from-email amount to-email params]
-  (let [wallet-store (:wallet-store stores-m)
-        from (wallet/fetch wallet-store from-email)
-        to (wallet/fetch wallet-store to-email)]
-    (blockchain/make-transaction blockchain (:account-id from) amount (:account-id to) params from-email))
+  (let [wallet-store (:wallet-store stores-m)]
+    (blockchain/make-transaction blockchain from-email amount to-email params))
   state)
-
 
 (defn check-page-is-activity-stream [state route-action & route-params]
   (apply kc/page-route-is state route-action route-params)

--- a/test/freecoin/journey/sign_in.clj
+++ b/test/freecoin/journey/sign_in.clj
@@ -20,7 +20,7 @@
 
 ;; TTL is set to 30 seconds but mongo checks only every ~60 secs
 (def stores-m (s/create-mongo-stores (ih/get-test-db) 30))
-(def blockchain (blockchain/new-stub stores-m))
+(def blockchain (blockchain/new-mongo stores-m))
 (def emails (atom []))
 
 (def test-app (ih/build-app {:stores-m stores-m

--- a/test/freecoin/journey/tags.clj
+++ b/test/freecoin/journey/tags.clj
@@ -57,15 +57,17 @@
 (facts "Tags can be listed"
        (let [memory (atom {})]
          (-> (k/session test-app)
-
              (jh/sign-up "recipient")
-             (jh/activate-account (jh/get-activation-id stores-m recipient-email) recipient-email)
+             (jh/activate-account {:activation-id (jh/get-activation-id stores-m recipient-email)
+                                   :email recipient-email}) 
              (jh/sign-in "recipient")
              (kh/remember memory :recipient-email kh/state-on-account-page->email)
              jh/sign-out
 
              (jh/sign-up "sender")
-             (jh/activate-account (jh/get-activation-id stores-m sender-email) sender-email)
+             (jh/activate-account {:activation-id (jh/get-activation-id stores-m sender-email)
+                                   :email sender-email
+                                   :stores-m stores-m})
              (jh/sign-in "sender")
              (kh/remember memory :sender-email kh/state-on-account-page->email)
 

--- a/test/freecoin/journey/tags.clj
+++ b/test/freecoin/journey/tags.clj
@@ -44,7 +44,7 @@
 (ih/setup-db)
 
 (def stores-m (s/create-mongo-stores (ih/get-test-db)))
-(def blockchain (blockchain/new-stub stores-m))
+(def blockchain (blockchain/new-mongo stores-m))
 
 (def test-app (ih/build-app {:stores-m stores-m
                              :blockchain blockchain

--- a/test/freecoin/journey/transactions.clj
+++ b/test/freecoin/journey/transactions.clj
@@ -17,7 +17,7 @@
 (ih/setup-db)
 
 (def stores-m (s/create-mongo-stores (ih/get-test-db)))
-(def blockchain (blockchain/new-stub stores-m))
+(def blockchain (blockchain/new-mongo stores-m))
 
 (def test-app (ih/build-app {:stores-m stores-m
                              :blockchain blockchain

--- a/test/freecoin/journey/transactions.clj
+++ b/test/freecoin/journey/transactions.clj
@@ -44,13 +44,16 @@
        (let [memory (atom {})]
          (-> (k/session test-app)
              (sign-up "recipient")
-             (activate-account (jh/get-activation-id stores-m recipient-email) recipient-email)
+             (activate-account {:activation-id (jh/get-activation-id stores-m recipient-email)
+                                :email recipient-email})
              (sign-in "recipient")
              (kh/remember memory :recipient-email kh/state-on-account-page->email)
              sign-out
 
              (sign-up "sender")
-             (activate-account (jh/get-activation-id stores-m sender-email) sender-email)
+             (activate-account {:activation-id (jh/get-activation-id stores-m sender-email)
+                                :email sender-email
+                                :stores-m stores-m})
              (sign-in "sender")
              (kh/remember memory :sender-email kh/state-on-account-page->email)
 
@@ -114,13 +117,15 @@
          (-> (k/session test-app)
 
              (sign-up "recipient")
-             (activate-account (jh/get-activation-id stores-m recipient-email) recipient-email)
+             (activate-account {:activation-id (jh/get-activation-id stores-m recipient-email) :email recipient-email})
              (sign-in "recipient")
              (kh/remember memory :recipient-email kh/state-on-account-page->email)
              sign-out
 
              (sign-up "sender")
-             (activate-account (jh/get-activation-id stores-m sender-email) sender-email)
+             (activate-account {:activation-id (jh/get-activation-id stores-m sender-email)
+                                :email sender-email
+                                :stores-m stores-m})
              (sign-in "sender")
              (kh/remember memory :sender-email kh/state-on-account-page->email)
 
@@ -148,13 +153,16 @@
          (-> (k/session test-app)
 
              (sign-up "recipient")
-             (activate-account (jh/get-activation-id stores-m recipient-email) recipient-email)
+             (activate-account {:activation-id (jh/get-activation-id stores-m recipient-email)
+                                :email recipient-email})
              (sign-in "recipient")
              (kh/remember memory :recipient-email kh/state-on-account-page->email)
              sign-out
 
              (sign-up "sender")
-             (activate-account (jh/get-activation-id stores-m sender-email) sender-email)
+             (activate-account {:activation-id (jh/get-activation-id stores-m sender-email)
+                                :email sender-email
+                                :stores-m stores-m})
              (sign-in "sender")
              (kh/remember memory :sender-email kh/state-on-account-page->email)
 
@@ -212,7 +220,8 @@
              (kh/remember memory :recipient-email kh/state-on-account-page->email) 
 
              (sign-up "sender")
-             (activate-account (jh/get-activation-id stores-m sender-email) sender-email)
+             (activate-account {:activation-id (jh/get-activation-id stores-m sender-email)
+                                :email sender-email})
              (sign-in "sender")
              (kh/remember memory :sender-email kh/state-on-account-page->email)
 
@@ -232,13 +241,16 @@
          (-> (k/session test-app)
 
              (sign-up "recipient")
-             (activate-account (jh/get-activation-id stores-m recipient-email) recipient-email)
+             (activate-account {:activation-id (jh/get-activation-id stores-m recipient-email)
+                                :email recipient-email})
              (sign-in "recipient")
              (kh/remember memory :recipient-email kh/state-on-account-page->email)
              sign-out
 
              (sign-up "sender")
-             (activate-account (jh/get-activation-id stores-m sender-email) sender-email)
+             (activate-account {:activation-id (jh/get-activation-id stores-m sender-email)
+                                :email sender-email
+                                :stores-m stores-m})
              (sign-in "sender")
              (kh/remember memory :sender-email kh/state-on-account-page->email)
 

--- a/test/freecoin/test/test_helper.clj
+++ b/test/freecoin/test/test_helper.clj
@@ -1,7 +1,8 @@
 (ns freecoin.test.test-helper
   (:require [midje.sweet :as midje]
             [ring.mock.request :as request]
-            [net.cgrand.enlive-html :as html]))
+            [net.cgrand.enlive-html :as html]
+            [freecoin-lib.db.account :as account]))
 
 (defn create-request
   ([method path query-m]
@@ -10,6 +11,15 @@
    (-> (request/request method path query-m)
        (assoc :params query-m)
        (assoc :session session))))
+
+(defn create-account [account-store
+                      {:keys [email active flags] :as account}]
+  (account/new-account! account-store {:first-name (str "name" (rand-int 100))
+                                       :last-name (str "surname" (rand-int 100))
+                                       :email email
+                                       :password (apply str (repeat 8 (rand 9)))
+                                       :active active
+                                       :flags flags}))
 
 (defn authenticated-session [email]
   {:signed-in-email email})


### PR DESCRIPTION
Freecoin side of the renaming story. Main points are:
- Rename the column admin to flags so an account can have a vector of keyword flags
- get tid of aacount-id when not needed
- replace the from-id and to-id with the email and get rid of from-email
- rename stub->mongo, blockchain->currency

Once the freecoin-lib 0.3.0 is released the tests should pass

@jaromil can you have a look please? We should merge after the lib is released and the tests are passing
